### PR TITLE
Consolidate shared CSS patterns to app.css (#17)

### DIFF
--- a/src/GexVisor.UI/Pages/BacktestResults.razor.css
+++ b/src/GexVisor.UI/Pages/BacktestResults.razor.css
@@ -15,40 +15,10 @@
     border-bottom: 1px solid var(--border-color);
 }
 
-.header-left {
-    display: flex;
-    align-items: center;
-    gap: 1.5rem;
-}
-
-.back-link {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 1rem;
-    background: var(--bg-card);
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
-    color: var(--text-muted);
-    text-decoration: none;
-    font-size: 0.875rem;
-    transition: all 0.2s ease;
-}
-
-.back-link:hover {
-    color: var(--accent-cyan);
-    border-color: var(--accent-cyan);
-}
-
 .backtest-header h1 {
     font-size: 1.25rem;
     font-weight: 600;
     margin: 0;
-}
-
-.header-actions {
-    display: flex;
-    gap: 0.75rem;
 }
 
 .btn-primary,
@@ -92,79 +62,6 @@
     opacity: 0.9;
 }
 
-.export-dropdown {
-    position: relative;
-}
-
-.dropdown-menu {
-    position: absolute;
-    top: 100%;
-    right: 0;
-    margin-top: 0.25rem;
-    background: var(--bg-panel);
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-    overflow: hidden;
-    z-index: 10;
-    min-width: 100px;
-}
-
-.dropdown-menu button {
-    display: block;
-    width: 100%;
-    padding: 0.5rem 1rem;
-    font-size: 0.8rem;
-    background: transparent;
-    border: none;
-    color: var(--text-primary);
-    text-align: left;
-    cursor: pointer;
-}
-
-.dropdown-menu button:hover {
-    background: var(--bg-card);
-}
-
-/* Stats Bar */
-.stats-bar {
-    display: flex;
-    gap: 1rem;
-    padding: 1rem 2rem;
-    background: var(--bg-card);
-    border-bottom: 1px solid var(--border-color);
-    overflow-x: auto;
-}
-
-.stat-card {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-    padding: 0.5rem 1rem;
-    background: var(--bg-panel);
-    border-radius: 6px;
-    min-width: 100px;
-}
-
-.stat-label {
-    font-size: 0.7rem;
-    color: var(--text-muted);
-    text-transform: uppercase;
-}
-
-.stat-value {
-    font-size: 1.1rem;
-    font-weight: 600;
-    font-family: 'JetBrains Mono', monospace;
-}
-
-.stat-value.positive {
-    color: var(--accent-green);
-}
-
-.stat-value.negative {
-    color: var(--accent-red);
-}
-
 /* Regime Bar */
 .regime-bar {
     display: flex;
@@ -203,27 +100,6 @@
     padding: 2rem;
     max-width: 1000px;
     margin: 0 auto;
-}
-
-.empty-state {
-    text-align: center;
-    padding: 4rem 2rem;
-    color: var(--text-muted);
-}
-
-.empty-icon {
-    font-size: 3rem;
-    margin-bottom: 1rem;
-}
-
-.empty-text {
-    font-size: 1.1rem;
-    font-weight: 600;
-    margin-bottom: 0.5rem;
-}
-
-.empty-hint {
-    font-size: 0.85rem;
 }
 
 /* Result List */
@@ -313,15 +189,6 @@
     margin-bottom: 0.5rem;
 }
 
-.tag {
-    padding: 0.15rem 0.4rem;
-    font-size: 0.65rem;
-    background: var(--bg-card);
-    border: 1px solid var(--border-color);
-    color: var(--accent-cyan);
-    border-radius: 3px;
-}
-
 .regime-breakdown {
     display: flex;
     gap: 1rem;
@@ -363,76 +230,7 @@
     background: rgba(239, 83, 80, 0.1);
 }
 
-/* Modal Styles */
-.modal-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.7);
-    backdrop-filter: blur(4px);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 1000;
-}
-
-.modal-content {
-    background: var(--bg-panel);
-    border: 1px solid var(--border-color);
-    border-radius: 12px;
-    width: 90%;
-    max-width: 500px;
-    max-height: 85vh;
-    overflow: hidden;
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
-}
-
-.modal-content.large {
-    max-width: 700px;
-}
-
-.modal-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1rem 1.25rem;
-    border-bottom: 1px solid var(--border-color);
-    background: var(--bg-card);
-}
-
-.modal-header h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    margin: 0;
-}
-
-.close-btn {
-    width: 28px;
-    height: 28px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: var(--bg-dark);
-    border: 1px solid var(--border-color);
-    color: var(--text-muted);
-    border-radius: 6px;
-    font-size: 1.25rem;
-    cursor: pointer;
-}
-
-.close-btn:hover {
-    background: var(--accent-red);
-    color: var(--bg-dark);
-}
-
-.modal-body {
-    padding: 1.25rem;
-    overflow-y: auto;
-    max-height: calc(85vh - 130px);
-}
-
+/* Form Section - Page-specific */
 .form-section {
     margin-bottom: 1.5rem;
 }
@@ -444,96 +242,6 @@
     margin: 0 0 0.75rem 0;
     text-transform: uppercase;
     letter-spacing: 0.05em;
-}
-
-.form-row {
-    margin-bottom: 1rem;
-}
-
-.form-row.two-col {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1rem;
-}
-
-.form-row.three-col {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    gap: 1rem;
-}
-
-.form-group {
-    margin-bottom: 0.75rem;
-}
-
-.form-group label {
-    display: block;
-    font-size: 0.8rem;
-    font-weight: 600;
-    color: var(--text-muted);
-    margin-bottom: 0.5rem;
-}
-
-.form-group input[type="text"],
-.form-group input[type="number"],
-.form-group textarea {
-    width: 100%;
-    padding: 0.6rem;
-    font-size: 0.85rem;
-    font-family: inherit;
-    background: var(--bg-card);
-    border: 1px solid var(--border-color);
-    color: var(--text-primary);
-    border-radius: 6px;
-}
-
-.form-group input:focus,
-.form-group textarea:focus {
-    outline: none;
-    border-color: var(--accent-cyan);
-}
-
-.form-group textarea {
-    resize: vertical;
-    min-height: 60px;
-}
-
-.modal-footer {
-    display: flex;
-    justify-content: flex-end;
-    gap: 0.5rem;
-    padding: 1rem 1.25rem;
-    border-top: 1px solid var(--border-color);
-    background: var(--bg-card);
-}
-
-.btn-cancel,
-.btn-save {
-    padding: 0.5rem 1rem;
-    font-size: 0.8rem;
-    font-weight: 600;
-    border-radius: 6px;
-    cursor: pointer;
-}
-
-.btn-cancel {
-    background: var(--bg-dark);
-    border: 1px solid var(--border-color);
-    color: var(--text-muted);
-}
-
-.btn-cancel:hover {
-    border-color: var(--text-muted);
-}
-
-.btn-save {
-    background: var(--accent-cyan);
-    border: none;
-    color: var(--bg-dark);
-}
-
-.btn-save:hover {
-    opacity: 0.9;
 }
 
 /* Detail Modal */
@@ -725,20 +433,6 @@
         flex-wrap: wrap;
     }
 
-    .stats-bar {
-        padding: 0.75rem 1rem;
-        gap: 0.5rem;
-    }
-
-    .stat-card {
-        min-width: 80px;
-        padding: 0.4rem 0.75rem;
-    }
-
-    .stat-value {
-        font-size: 0.95rem;
-    }
-
     .regime-bar {
         flex-wrap: wrap;
         gap: 1rem;
@@ -760,11 +454,6 @@
 
     .result-actions {
         align-self: flex-end;
-    }
-
-    .form-row.two-col,
-    .form-row.three-col {
-        grid-template-columns: 1fr;
     }
 
     .metrics-grid {

--- a/src/GexVisor.UI/Pages/PaperTrading.razor.css
+++ b/src/GexVisor.UI/Pages/PaperTrading.razor.css
@@ -15,40 +15,10 @@
     border-bottom: 1px solid var(--border-color);
 }
 
-.header-left {
-    display: flex;
-    align-items: center;
-    gap: 1.5rem;
-}
-
-.back-link {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 1rem;
-    background: var(--bg-card);
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
-    color: var(--text-muted);
-    text-decoration: none;
-    font-size: 0.875rem;
-    transition: all 0.2s ease;
-}
-
-.back-link:hover {
-    color: var(--accent-cyan);
-    border-color: var(--accent-cyan);
-}
-
 .trading-header h1 {
     font-size: 1.25rem;
     font-weight: 600;
     margin: 0;
-}
-
-.header-actions {
-    display: flex;
-    gap: 0.75rem;
 }
 
 .btn-primary,
@@ -79,79 +49,6 @@
 
 .btn-secondary:hover {
     border-color: var(--accent-cyan);
-}
-
-.export-dropdown {
-    position: relative;
-}
-
-.dropdown-menu {
-    position: absolute;
-    top: 100%;
-    right: 0;
-    margin-top: 0.25rem;
-    background: var(--bg-panel);
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-    overflow: hidden;
-    z-index: 10;
-    min-width: 100px;
-}
-
-.dropdown-menu button {
-    display: block;
-    width: 100%;
-    padding: 0.5rem 1rem;
-    font-size: 0.8rem;
-    background: transparent;
-    border: none;
-    color: var(--text-primary);
-    text-align: left;
-    cursor: pointer;
-}
-
-.dropdown-menu button:hover {
-    background: var(--bg-card);
-}
-
-/* Stats Bar */
-.stats-bar {
-    display: flex;
-    gap: 1rem;
-    padding: 1rem 2rem;
-    background: var(--bg-card);
-    border-bottom: 1px solid var(--border-color);
-    overflow-x: auto;
-}
-
-.stat-card {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-    padding: 0.5rem 1rem;
-    background: var(--bg-panel);
-    border-radius: 6px;
-    min-width: 100px;
-}
-
-.stat-label {
-    font-size: 0.7rem;
-    color: var(--text-muted);
-    text-transform: uppercase;
-}
-
-.stat-value {
-    font-size: 1.1rem;
-    font-weight: 600;
-    font-family: 'JetBrains Mono', monospace;
-}
-
-.stat-value.positive {
-    color: var(--accent-green);
-}
-
-.stat-value.negative {
-    color: var(--accent-red);
 }
 
 /* Tab Bar */
@@ -189,27 +86,6 @@
     padding: 2rem;
     max-width: 1000px;
     margin: 0 auto;
-}
-
-.empty-state {
-    text-align: center;
-    padding: 4rem 2rem;
-    color: var(--text-muted);
-}
-
-.empty-icon {
-    font-size: 3rem;
-    margin-bottom: 1rem;
-}
-
-.empty-text {
-    font-size: 1.1rem;
-    font-weight: 600;
-    margin-bottom: 0.5rem;
-}
-
-.empty-hint {
-    font-size: 0.85rem;
 }
 
 /* Trade List */
@@ -365,15 +241,6 @@
     margin-bottom: 0.5rem;
 }
 
-.tag {
-    padding: 0.15rem 0.4rem;
-    font-size: 0.65rem;
-    background: var(--bg-card);
-    border: 1px solid var(--border-color);
-    color: var(--accent-cyan);
-    border-radius: 3px;
-}
-
 .trade-context {
     display: flex;
     gap: 0.5rem;
@@ -459,122 +326,7 @@
     border-left: 3px solid var(--accent-cyan);
 }
 
-/* Modal Styles */
-.modal-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.7);
-    backdrop-filter: blur(4px);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 1000;
-}
-
-.modal-content {
-    background: var(--bg-panel);
-    border: 1px solid var(--border-color);
-    border-radius: 12px;
-    width: 90%;
-    max-width: 500px;
-    max-height: 85vh;
-    overflow: hidden;
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
-}
-
-.modal-content.small {
-    max-width: 400px;
-}
-
-.modal-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1rem 1.25rem;
-    border-bottom: 1px solid var(--border-color);
-    background: var(--bg-card);
-}
-
-.modal-header h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    margin: 0;
-}
-
-.close-btn {
-    width: 28px;
-    height: 28px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: var(--bg-dark);
-    border: 1px solid var(--border-color);
-    color: var(--text-muted);
-    border-radius: 6px;
-    font-size: 1.25rem;
-    cursor: pointer;
-}
-
-.close-btn:hover {
-    background: var(--accent-red);
-    color: var(--bg-dark);
-}
-
-.modal-body {
-    padding: 1.25rem;
-    overflow-y: auto;
-    max-height: calc(85vh - 130px);
-}
-
-.form-row {
-    margin-bottom: 1rem;
-}
-
-.form-row.two-col {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1rem;
-}
-
-.form-group {
-    margin-bottom: 1rem;
-}
-
-.form-group label {
-    display: block;
-    font-size: 0.8rem;
-    font-weight: 600;
-    color: var(--text-muted);
-    margin-bottom: 0.5rem;
-}
-
-.form-group input[type="text"],
-.form-group input[type="number"],
-.form-group textarea {
-    width: 100%;
-    padding: 0.6rem;
-    font-size: 0.85rem;
-    font-family: inherit;
-    background: var(--bg-card);
-    border: 1px solid var(--border-color);
-    color: var(--text-primary);
-    border-radius: 6px;
-}
-
-.form-group input:focus,
-.form-group textarea:focus {
-    outline: none;
-    border-color: var(--accent-cyan);
-}
-
-.form-group textarea {
-    resize: vertical;
-    min-height: 80px;
-}
-
+/* Trade Modal - Page-specific */
 .direction-toggle {
     display: flex;
     gap: 0.5rem;
@@ -658,44 +410,6 @@
     color: var(--accent-red);
 }
 
-.modal-footer {
-    display: flex;
-    justify-content: flex-end;
-    gap: 0.5rem;
-    padding: 1rem 1.25rem;
-    border-top: 1px solid var(--border-color);
-    background: var(--bg-card);
-}
-
-.btn-cancel,
-.btn-save {
-    padding: 0.5rem 1rem;
-    font-size: 0.8rem;
-    font-weight: 600;
-    border-radius: 6px;
-    cursor: pointer;
-}
-
-.btn-cancel {
-    background: var(--bg-dark);
-    border: 1px solid var(--border-color);
-    color: var(--text-muted);
-}
-
-.btn-cancel:hover {
-    border-color: var(--text-muted);
-}
-
-.btn-save {
-    background: var(--accent-cyan);
-    border: none;
-    color: var(--bg-dark);
-}
-
-.btn-save:hover {
-    opacity: 0.9;
-}
-
 /* Mobile Responsive */
 @media (max-width: 768px) {
     .trading-header {
@@ -717,20 +431,6 @@
         justify-content: flex-end;
     }
 
-    .stats-bar {
-        padding: 0.75rem 1rem;
-        gap: 0.5rem;
-    }
-
-    .stat-card {
-        min-width: 80px;
-        padding: 0.4rem 0.75rem;
-    }
-
-    .stat-value {
-        font-size: 0.95rem;
-    }
-
     .tab-bar {
         padding: 0 1rem;
         overflow-x: auto;
@@ -750,17 +450,9 @@
         padding: 0.875rem;
     }
 
-    .form-row.two-col {
-        grid-template-columns: 1fr;
-    }
-
     .pattern-grid,
     .regime-grid {
         grid-template-columns: 1fr;
-    }
-
-    .modal-body {
-        padding: 1rem;
     }
 
     .direction-toggle {

--- a/src/GexVisor.UI/Pages/ResearchArcade.razor.css
+++ b/src/GexVisor.UI/Pages/ResearchArcade.razor.css
@@ -15,25 +15,9 @@
     margin-bottom: 2rem;
 }
 
+/* Override: center the back-link content */
 .back-link {
-    display: flex;
-    align-items: center;
     justify-content: center;
-    gap: 0.5rem;
-    padding: 0.5rem 1rem;
-    background: var(--bg-card);
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
-    color: var(--text-muted);
-    text-decoration: none;
-    font-size: 0.875rem;
-    transition: all 0.2s ease;
-}
-
-.back-link:hover {
-    color: var(--accent-cyan);
-    border-color: var(--accent-cyan);
-    text-decoration: none;
 }
 
 .header-content h1 {

--- a/src/GexVisor.UI/Pages/ResearchNotebook.razor.css
+++ b/src/GexVisor.UI/Pages/ResearchNotebook.razor.css
@@ -15,40 +15,10 @@
     border-bottom: 1px solid var(--border-color);
 }
 
-.header-left {
-    display: flex;
-    align-items: center;
-    gap: 1.5rem;
-}
-
-.back-link {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 1rem;
-    background: var(--bg-card);
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
-    color: var(--text-muted);
-    text-decoration: none;
-    font-size: 0.875rem;
-    transition: all 0.2s ease;
-}
-
-.back-link:hover {
-    color: var(--accent-cyan);
-    border-color: var(--accent-cyan);
-}
-
 .notebook-header h1 {
     font-size: 1.25rem;
     font-weight: 600;
     margin: 0;
-}
-
-.header-actions {
-    display: flex;
-    gap: 0.75rem;
 }
 
 .btn-primary,
@@ -79,39 +49,6 @@
 
 .btn-secondary:hover {
     border-color: var(--accent-cyan);
-}
-
-.export-dropdown {
-    position: relative;
-}
-
-.dropdown-menu {
-    position: absolute;
-    top: 100%;
-    right: 0;
-    margin-top: 0.25rem;
-    background: var(--bg-panel);
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-    overflow: hidden;
-    z-index: 10;
-    min-width: 120px;
-}
-
-.dropdown-menu button {
-    display: block;
-    width: 100%;
-    padding: 0.5rem 1rem;
-    font-size: 0.8rem;
-    background: transparent;
-    border: none;
-    color: var(--text-primary);
-    text-align: left;
-    cursor: pointer;
-}
-
-.dropdown-menu button:hover {
-    background: var(--bg-card);
 }
 
 .notebook-toolbar {
@@ -177,27 +114,6 @@
     padding: 2rem;
     max-width: 1200px;
     margin: 0 auto;
-}
-
-.empty-state {
-    text-align: center;
-    padding: 4rem 2rem;
-    color: var(--text-muted);
-}
-
-.empty-icon {
-    font-size: 3rem;
-    margin-bottom: 1rem;
-}
-
-.empty-text {
-    font-size: 1.1rem;
-    font-weight: 600;
-    margin-bottom: 0.5rem;
-}
-
-.empty-hint {
-    font-size: 0.85rem;
 }
 
 .entry-list {
@@ -300,19 +216,6 @@
     margin-bottom: 0.5rem;
 }
 
-.tag {
-    padding: 0.15rem 0.4rem;
-    font-size: 0.65rem;
-    background: var(--bg-card);
-    border: 1px solid var(--border-color);
-    color: var(--accent-cyan);
-    border-radius: 3px;
-}
-
-.tag.more {
-    color: var(--text-muted);
-}
-
 .entry-context {
     display: flex;
     gap: 0.5rem;
@@ -334,147 +237,13 @@
     color: var(--accent-red);
 }
 
-/* Modal Styles */
-.modal-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.7);
-    backdrop-filter: blur(4px);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 1000;
-}
-
-.modal-content {
-    background: var(--bg-panel);
-    border: 1px solid var(--border-color);
-    border-radius: 12px;
-    width: 90%;
-    max-width: 500px;
-    max-height: 85vh;
-    overflow: hidden;
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
-}
-
-.modal-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1rem 1.25rem;
-    border-bottom: 1px solid var(--border-color);
-    background: var(--bg-card);
-}
-
-.modal-header h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    margin: 0;
-}
-
-.close-btn {
-    width: 28px;
-    height: 28px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: var(--bg-dark);
-    border: 1px solid var(--border-color);
-    color: var(--text-muted);
-    border-radius: 6px;
-    font-size: 1.25rem;
-    cursor: pointer;
-}
-
-.close-btn:hover {
-    background: var(--accent-red);
-    color: var(--bg-dark);
-}
-
-.modal-body {
-    padding: 1.25rem;
-    overflow-y: auto;
-    max-height: calc(85vh - 130px);
-}
-
-.form-group {
-    margin-bottom: 1rem;
-}
-
-.form-group label {
-    display: block;
-    font-size: 0.8rem;
-    font-weight: 600;
-    color: var(--text-muted);
-    margin-bottom: 0.5rem;
-}
-
-.form-group input[type="text"],
+/* Page-specific form override */
 .form-group textarea {
-    width: 100%;
-    padding: 0.6rem;
-    font-size: 0.85rem;
-    font-family: inherit;
-    background: var(--bg-card);
-    border: 1px solid var(--border-color);
-    color: var(--text-primary);
-    border-radius: 6px;
-}
-
-.form-group input:focus,
-.form-group textarea:focus {
-    outline: none;
-    border-color: var(--accent-cyan);
-}
-
-.form-group textarea {
-    resize: vertical;
     min-height: 120px;
 }
 
 .form-group input[type="checkbox"] {
     margin-right: 0.5rem;
-}
-
-.modal-footer {
-    display: flex;
-    justify-content: flex-end;
-    gap: 0.5rem;
-    padding: 1rem 1.25rem;
-    border-top: 1px solid var(--border-color);
-    background: var(--bg-card);
-}
-
-.btn-cancel,
-.btn-save {
-    padding: 0.5rem 1rem;
-    font-size: 0.8rem;
-    font-weight: 600;
-    border-radius: 6px;
-    cursor: pointer;
-}
-
-.btn-cancel {
-    background: var(--bg-dark);
-    border: 1px solid var(--border-color);
-    color: var(--text-muted);
-}
-
-.btn-cancel:hover {
-    border-color: var(--text-muted);
-}
-
-.btn-save {
-    background: var(--accent-cyan);
-    border: none;
-    color: var(--bg-dark);
-}
-
-.btn-save:hover {
-    opacity: 0.9;
 }
 
 /* Mobile Responsive */
@@ -534,9 +303,5 @@
     .entry-actions {
         opacity: 1;
         align-self: flex-end;
-    }
-
-    .modal-body {
-        padding: 1rem;
     }
 }

--- a/src/GexVisor.UI/Pages/TaskBoard.razor.css
+++ b/src/GexVisor.UI/Pages/TaskBoard.razor.css
@@ -15,31 +15,6 @@
     border-bottom: 1px solid var(--border-color);
 }
 
-.header-left {
-    display: flex;
-    align-items: center;
-    gap: 1.5rem;
-}
-
-.back-link {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 1rem;
-    background: var(--bg-card);
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
-    color: var(--text-muted);
-    text-decoration: none;
-    font-size: 0.875rem;
-    transition: all 0.2s ease;
-}
-
-.back-link:hover {
-    color: var(--accent-cyan);
-    border-color: var(--accent-cyan);
-}
-
 .taskboard-header h1 {
     font-size: 1.25rem;
     font-weight: 600;
@@ -47,11 +22,6 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
-}
-
-.header-actions {
-    display: flex;
-    gap: 0.75rem;
 }
 
 .btn-primary,
@@ -297,15 +267,6 @@
     margin-bottom: 0.5rem;
 }
 
-.tag {
-    padding: 0.1rem 0.35rem;
-    font-size: 0.65rem;
-    background: var(--bg-panel);
-    border: 1px solid var(--border-color);
-    color: var(--accent-cyan);
-    border-radius: 3px;
-}
-
 .task-actions {
     display: flex;
     gap: 0.25rem;
@@ -401,117 +362,6 @@
     color: var(--accent-cyan);
 }
 
-/* Modal Styles */
-.modal-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.7);
-    backdrop-filter: blur(4px);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 1000;
-}
-
-.modal-content {
-    background: var(--bg-panel);
-    border: 1px solid var(--border-color);
-    border-radius: 12px;
-    width: 90%;
-    max-width: 500px;
-    max-height: 85vh;
-    overflow: hidden;
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
-}
-
-.modal-content.large {
-    max-width: 700px;
-}
-
-.modal-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1rem 1.25rem;
-    border-bottom: 1px solid var(--border-color);
-    background: var(--bg-card);
-}
-
-.modal-header h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    margin: 0;
-}
-
-.close-btn {
-    width: 28px;
-    height: 28px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: var(--bg-dark);
-    border: 1px solid var(--border-color);
-    color: var(--text-muted);
-    border-radius: 6px;
-    font-size: 1.25rem;
-    cursor: pointer;
-}
-
-.close-btn:hover {
-    background: var(--accent-red);
-    color: var(--bg-dark);
-}
-
-.modal-body {
-    padding: 1.25rem;
-    overflow-y: auto;
-    max-height: calc(85vh - 130px);
-}
-
-.form-group {
-    margin-bottom: 1rem;
-}
-
-.form-group label {
-    display: block;
-    font-size: 0.8rem;
-    font-weight: 600;
-    color: var(--text-muted);
-    margin-bottom: 0.5rem;
-}
-
-.form-group input[type="text"],
-.form-group textarea {
-    width: 100%;
-    padding: 0.6rem;
-    font-size: 0.85rem;
-    font-family: inherit;
-    background: var(--bg-card);
-    border: 1px solid var(--border-color);
-    color: var(--text-primary);
-    border-radius: 6px;
-}
-
-.form-group input:focus,
-.form-group textarea:focus {
-    outline: none;
-    border-color: var(--accent-cyan);
-}
-
-.form-group textarea {
-    resize: vertical;
-    min-height: 80px;
-}
-
-.form-row.two-col {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1rem;
-}
-
 /* Priority Buttons */
 .priority-buttons,
 .status-buttons {
@@ -567,48 +417,6 @@
     background: rgba(0, 200, 83, 0.2);
     border-color: var(--accent-green);
     color: var(--accent-green);
-}
-
-.modal-footer {
-    display: flex;
-    justify-content: flex-end;
-    gap: 0.5rem;
-    padding: 1rem 1.25rem;
-    border-top: 1px solid var(--border-color);
-    background: var(--bg-card);
-}
-
-.btn-cancel,
-.btn-save,
-.btn-delete {
-    padding: 0.5rem 1rem;
-    font-size: 0.8rem;
-    font-weight: 600;
-    border-radius: 6px;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-}
-
-.btn-cancel {
-    background: var(--bg-dark);
-    border: 1px solid var(--border-color);
-    color: var(--text-muted);
-}
-
-.btn-cancel:hover {
-    border-color: var(--text-muted);
-}
-
-.btn-save {
-    background: var(--accent-cyan);
-    border: none;
-    color: var(--bg-dark);
-}
-
-.btn-save:hover {
-    opacity: 0.9;
 }
 
 .btn-save:disabled {
@@ -898,14 +706,5 @@
     .github-board-container,
     .unified-board-container {
         padding: 1rem;
-    }
-
-    .modal-content {
-        margin: 1rem;
-        max-height: calc(100vh - 2rem);
-    }
-
-    .form-row.two-col {
-        grid-template-columns: 1fr;
     }
 }

--- a/src/GexVisor.UI/wwwroot/css/app.css
+++ b/src/GexVisor.UI/wwwroot/css/app.css
@@ -260,3 +260,342 @@ tr:hover {
 .skip-link:focus {
     top: 0;
 }
+
+/* ================================
+   Shared Component Styles
+   ================================ */
+
+/* Back Link - navigation pill */
+.back-link {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    color: var(--text-muted);
+    text-decoration: none;
+    font-size: 0.875rem;
+    transition: all 0.2s ease;
+}
+
+.back-link:hover {
+    color: var(--accent-cyan);
+    border-color: var(--accent-cyan);
+    text-decoration: none;
+}
+
+/* Header Layout Pattern */
+.header-left {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+}
+
+.header-actions {
+    display: flex;
+    gap: 0.75rem;
+}
+
+/* Modal System */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(4px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.modal-content {
+    background: var(--bg-panel);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    width: 90%;
+    max-width: 500px;
+    max-height: 85vh;
+    overflow: hidden;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+}
+
+.modal-content.small {
+    max-width: 400px;
+}
+
+.modal-content.large {
+    max-width: 700px;
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid var(--border-color);
+    background: var(--bg-card);
+}
+
+.modal-header h2 {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0;
+}
+
+.modal-body {
+    padding: 1.25rem;
+    overflow-y: auto;
+    max-height: calc(85vh - 130px);
+}
+
+.modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    padding: 1rem 1.25rem;
+    border-top: 1px solid var(--border-color);
+    background: var(--bg-card);
+}
+
+.close-btn {
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--bg-dark);
+    border: 1px solid var(--border-color);
+    color: var(--text-muted);
+    border-radius: 6px;
+    font-size: 1.25rem;
+    cursor: pointer;
+}
+
+.close-btn:hover {
+    background: var(--accent-red);
+    color: var(--bg-dark);
+}
+
+/* Form Groups */
+.form-group {
+    margin-bottom: 1rem;
+}
+
+.form-group label {
+    display: block;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    margin-bottom: 0.5rem;
+}
+
+.form-group input[type="text"],
+.form-group input[type="number"],
+.form-group textarea {
+    width: 100%;
+    padding: 0.6rem;
+    font-size: 0.85rem;
+    font-family: inherit;
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    color: var(--text-primary);
+    border-radius: 6px;
+}
+
+.form-group input:focus,
+.form-group textarea:focus {
+    outline: none;
+    border-color: var(--accent-cyan);
+}
+
+.form-group textarea {
+    resize: vertical;
+    min-height: 80px;
+}
+
+.form-row {
+    margin-bottom: 1rem;
+}
+
+.form-row.two-col {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+}
+
+.form-row.three-col {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 1rem;
+}
+
+/* Action Buttons */
+.btn-cancel,
+.btn-save {
+    padding: 0.5rem 1rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.btn-cancel {
+    background: var(--bg-dark);
+    border: 1px solid var(--border-color);
+    color: var(--text-muted);
+}
+
+.btn-cancel:hover {
+    border-color: var(--text-muted);
+}
+
+.btn-save {
+    background: var(--accent-cyan);
+    border: none;
+    color: var(--bg-dark);
+}
+
+.btn-save:hover {
+    opacity: 0.9;
+}
+
+/* Empty State */
+.empty-state {
+    text-align: center;
+    padding: 4rem 2rem;
+    color: var(--text-muted);
+}
+
+.empty-icon {
+    font-size: 3rem;
+    margin-bottom: 1rem;
+}
+
+.empty-text {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+}
+
+.empty-hint {
+    font-size: 0.85rem;
+}
+
+/* Tag Pills */
+.tag {
+    padding: 0.15rem 0.4rem;
+    font-size: 0.65rem;
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    color: var(--accent-cyan);
+    border-radius: 3px;
+}
+
+.tag.more {
+    color: var(--text-muted);
+}
+
+/* Stats Bar */
+.stats-bar {
+    display: flex;
+    gap: 1rem;
+    padding: 1rem 2rem;
+    background: var(--bg-card);
+    border-bottom: 1px solid var(--border-color);
+    overflow-x: auto;
+}
+
+.stat-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.5rem 1rem;
+    background: var(--bg-panel);
+    border-radius: 6px;
+    min-width: 100px;
+}
+
+.stat-label {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+}
+
+.stat-value {
+    font-size: 1.1rem;
+    font-weight: 600;
+    font-family: 'JetBrains Mono', monospace;
+}
+
+.stat-value.positive {
+    color: var(--accent-green);
+}
+
+.stat-value.negative {
+    color: var(--accent-red);
+}
+
+/* Dropdown Menu */
+.export-dropdown {
+    position: relative;
+}
+
+.dropdown-menu {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 0.25rem;
+    background: var(--bg-panel);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    overflow: hidden;
+    z-index: 10;
+    min-width: 100px;
+}
+
+.dropdown-menu button {
+    display: block;
+    width: 100%;
+    padding: 0.5rem 1rem;
+    font-size: 0.8rem;
+    background: transparent;
+    border: none;
+    color: var(--text-primary);
+    text-align: left;
+    cursor: pointer;
+}
+
+.dropdown-menu button:hover {
+    background: var(--bg-card);
+}
+
+/* Mobile Responsive - Shared */
+@media (max-width: 768px) {
+    .form-row.two-col,
+    .form-row.three-col {
+        grid-template-columns: 1fr;
+    }
+
+    .modal-body {
+        padding: 1rem;
+    }
+
+    .stats-bar {
+        padding: 0.75rem 1rem;
+        gap: 0.5rem;
+    }
+
+    .stat-card {
+        min-width: 80px;
+        padding: 0.4rem 0.75rem;
+    }
+
+    .stat-value {
+        font-size: 0.95rem;
+    }
+}


### PR DESCRIPTION
## Summary
- Extract common component styles (modals, forms, buttons, stats bars, empty states, dropdowns) to app.css
- Remove duplicate CSS from page-specific CSS files (PaperTrading, BacktestResults, TaskBoard, ResearchNotebook, ResearchArcade)
- Net reduction: ~730 lines of duplicate CSS removed

## Test plan
- [ ] Visual inspection of all pages to verify styles are maintained
- [ ] Check modal appearance across PaperTrading, BacktestResults, TaskBoard, ResearchNotebook
- [ ] Verify back-link styling on all pages
- [ ] Confirm mobile responsive behavior unchanged