### PR TITLE
feat: Extract IGexStateService interface for testability

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -297,7 +297,7 @@ Tracked in GitHub issues:
 
 ### Hard to Test (Requires Mocking)
 
-- `GexStateService` - No interface, timer-based simulation
+- `GexStateService` - Timer-based simulation, requires careful mocking
 - `BoardStateService` - Complex cache lifecycle
 - `GitHubAuthService` - Polling loop, external API
 
@@ -307,7 +307,7 @@ Tracked in GitHub issues:
 |---------|---------------|----------|
 | GexDataService | ✅ IGexDataService | Yes |
 | LocalStorageService | ✅ ILocalStorageService | Yes |
-| GexStateService | ❌ None | No (blocker) |
+| GexStateService | ✅ IGexStateService | Yes |
 | ComparisonAnalysisService | ❌ None | Yes (stateless) |
 
 ---

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -300,7 +300,8 @@ All 20 services with their dependencies and coupling analysis.
 ```mermaid
 flowchart TB
     subgraph Singleton["Singleton (App-wide State)"]
-        GSS[GexStateService<br/>⚠️ No interface]
+        GSS[GexStateService]
+        IGSS{{IGexStateService}}
     end
 
     subgraph Core["Core Services"]
@@ -342,6 +343,7 @@ flowchart TB
         LS[(localStorage)]
     end
 
+    GSS -->|implements| IGSS
     GDS -->|implements| IGDS
     LSS -->|implements| ILSS
     GDS --> HTTP
@@ -362,7 +364,7 @@ flowchart TB
     CS --> IGDS
     TS --> ILSS
 
-    GSS -.->|tight coupling| GDS
+    GSS --> GDS
 ```
 
 ### Complete Data Flow

--- a/src/GexVisor.UI/Components/Gex/AnnotationPanel.razor
+++ b/src/GexVisor.UI/Components/Gex/AnnotationPanel.razor
@@ -3,7 +3,7 @@
 @using GexVisor.UI.Models
 @using GexVisor.UI.Services
 @inject AnnotationService AnnotationService
-@inject GexStateService StateService
+@inject IGexStateService StateService
 @inject IJSRuntime JS
 @implements IDisposable
 

--- a/src/GexVisor.UI/Components/Gex/GexChart.razor
+++ b/src/GexVisor.UI/Components/Gex/GexChart.razor
@@ -1,7 +1,7 @@
 @using GexVisor.UI.Models
 @using GexVisor.UI.Services
 @using Microsoft.JSInterop
-@inject GexStateService StateService
+@inject IGexStateService StateService
 @inject IJSRuntime JS
 @implements IAsyncDisposable
 

--- a/src/GexVisor.UI/Components/Gex/GexHeader.razor
+++ b/src/GexVisor.UI/Components/Gex/GexHeader.razor
@@ -1,7 +1,7 @@
 @using GexVisor.UI.Configuration
 @using GexVisor.UI.Models
 @using GexVisor.UI.Services
-@inject GexStateService StateService
+@inject IGexStateService StateService
 @inject IJSRuntime JS
 @implements IDisposable
 

--- a/src/GexVisor.UI/Components/Gex/GexSidebar.razor
+++ b/src/GexVisor.UI/Components/Gex/GexSidebar.razor
@@ -1,7 +1,7 @@
 @using GexVisor.UI.Configuration
 @using GexVisor.UI.Models
 @using GexVisor.UI.Services
-@inject GexStateService StateService
+@inject IGexStateService StateService
 @inject GexDataService DataService
 @implements IDisposable
 

--- a/src/GexVisor.UI/Components/Gex/PriceSparkline.razor
+++ b/src/GexVisor.UI/Components/Gex/PriceSparkline.razor
@@ -1,6 +1,6 @@
 @using GexVisor.UI.Models
 @using GexVisor.UI.Services
-@inject GexStateService StateService
+@inject IGexStateService StateService
 @implements IDisposable
 
 <div class="price-chart-card">

--- a/src/GexVisor.UI/Pages/GexVisualizer.razor
+++ b/src/GexVisor.UI/Pages/GexVisualizer.razor
@@ -75,7 +75,7 @@
 <AnnotationPanel />
 
 @code {
-    [Inject] private GexStateService StateService { get; set; } = default!;
+    [Inject] private IGexStateService StateService { get; set; } = default!;
 
     private ElementReference _appRef;
     private bool _preventKeyDefault;

--- a/src/GexVisor.UI/Program.cs
+++ b/src/GexVisor.UI/Program.cs
@@ -10,7 +10,7 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
 // GEX Visualizer Services
-builder.Services.AddSingleton<GexStateService>();
+builder.Services.AddSingleton<IGexStateService, GexStateService>();
 builder.Services.AddScoped<IGexDataService, GexDataService>();
 builder.Services.AddScoped<ILocalStorageService, LocalStorageService>();
 builder.Services.AddScoped<AnnotationService>();

--- a/src/GexVisor.UI/Services/GexStateService.cs
+++ b/src/GexVisor.UI/Services/GexStateService.cs
@@ -9,7 +9,7 @@ namespace GexVisor.UI.Services;
 /// Manages application state for the GEX visualizer.
 /// Provides reactive state updates via events.
 /// </summary>
-public class GexStateService : IDisposable
+public class GexStateService : IGexStateService
 {
     private readonly GexState _state = new();
     private List<GexDataPoint> _timeline = [];

--- a/src/GexVisor.UI/Services/IGexStateService.cs
+++ b/src/GexVisor.UI/Services/IGexStateService.cs
@@ -1,0 +1,137 @@
+using GexVisor.UI.Configuration;
+using GexVisor.UI.Models;
+
+namespace GexVisor.UI.Services;
+
+/// <summary>
+/// Interface for the GEX state service providing reactive state management
+/// for the visualizer. Enables dependency injection and testability.
+/// </summary>
+public interface IGexStateService : IDisposable
+{
+    /// <summary>
+    /// Fired when any state property changes.
+    /// </summary>
+    event Action? OnStateChanged;
+
+    /// <summary>
+    /// Fired when settings (axis scales, playback speed) change.
+    /// Used for persistence triggers.
+    /// </summary>
+    event Action? OnSettingsChanged;
+
+    /// <summary>
+    /// Current visualization state.
+    /// </summary>
+    GexState State { get; }
+
+    /// <summary>
+    /// Current timeline data points.
+    /// </summary>
+    IReadOnlyList<GexDataPoint> Timeline { get; }
+
+    /// <summary>
+    /// Built-in demo timeline for offline use.
+    /// </summary>
+    IReadOnlyList<GexDataPoint> DemoTimeline { get; }
+
+    /// <summary>
+    /// Set the timeline from loaded data.
+    /// </summary>
+    void SetTimeline(List<GexDataPoint> timeline);
+
+    /// <summary>
+    /// Reset to demo timeline.
+    /// </summary>
+    void ResetToDemoTimeline();
+
+    /// <summary>
+    /// Update the current index and sync state values.
+    /// </summary>
+    void SetCurrentIndex(int index);
+
+    /// <summary>
+    /// Step forward in the timeline.
+    /// </summary>
+    void StepForward();
+
+    /// <summary>
+    /// Step backward in the timeline.
+    /// </summary>
+    void StepBackward();
+
+    /// <summary>
+    /// Jump to start of timeline.
+    /// </summary>
+    void JumpToStart();
+
+    /// <summary>
+    /// Jump to end of timeline.
+    /// </summary>
+    void JumpToEnd();
+
+    /// <summary>
+    /// Update strike range based on current price data.
+    /// </summary>
+    void UpdateStrikeRange();
+
+    /// <summary>
+    /// Update manual price value (for slider controls).
+    /// </summary>
+    void UpdatePrice(decimal price);
+
+    /// <summary>
+    /// Update manual open interest value (for slider controls).
+    /// </summary>
+    void UpdateOpenInterest(decimal oi);
+
+    /// <summary>
+    /// Update manual tilt value (for slider controls).
+    /// </summary>
+    void UpdateTilt(decimal tilt);
+
+    /// <summary>
+    /// Reset axis zoom scales to default.
+    /// </summary>
+    void ResetView();
+
+    /// <summary>
+    /// Adjust Y-axis zoom scale.
+    /// </summary>
+    void AdjustYAxisScale(decimal delta);
+
+    /// <summary>
+    /// Adjust X-axis zoom scale.
+    /// </summary>
+    void AdjustXAxisScale(decimal delta);
+
+    /// <summary>
+    /// Get current settings for persistence.
+    /// </summary>
+    AppSettings GetSettings();
+
+    /// <summary>
+    /// Apply settings from storage.
+    /// </summary>
+    void ApplySettings(AppSettings settings);
+
+    /// <summary>
+    /// Toggle simulation playback.
+    /// </summary>
+    void ToggleSimulation();
+
+    /// <summary>
+    /// Set playback speed (1 = 0.5x, 2 = 1x, 4 = 2x).
+    /// </summary>
+    void SetPlaybackSpeed(int speed);
+
+    /// <summary>
+    /// Set data mode (Demo or Real).
+    /// </summary>
+    void SetDataMode(DataMode mode);
+
+    /// <summary>
+    /// Get regime analysis for the current timeline.
+    /// </summary>
+    RegimeAnalysisSummary? GetRegimeAnalysis();
+}


### PR DESCRIPTION
## Summary

- Create `IGexStateService` interface with full public API surface (22 members)
- Update `GexStateService` to implement `IGexStateService`
- Update DI registration to use interface-based injection
- Update all 6 components to inject `IGexStateService` instead of concrete type
- Update architecture documentation to reflect new interface

## Impact

Components updated:
- `AnnotationPanel.razor`
- `GexChart.razor`
- `GexHeader.razor`
- `GexSidebar.razor`
- `GexVisualizer.razor`
- `PriceSparkline.razor`

## Benefits

1. **Testability**: GexStateService can now be mocked in unit tests
2. **Decoupling**: Components depend on abstraction, not implementation
3. **Extensibility**: Alternative implementations possible for testing/demos

## Test plan

- [x] Build succeeds
- [x] All Core tests pass (17/17)
- [x] All UI tests pass (132/132, excluding pre-existing Trade Journal failures)
- [x] No new warnings introduced

Closes #134